### PR TITLE
fix: module path name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Hari-Kiri/virest-utilities/utils
+module github.com/Hari-Kiri/virest-utilitiess
 
 go 1.23.4
 


### PR DESCRIPTION
Fixing error when importing to other virest library.

> go: github.com/Hari-Kiri/virest-utilities@v0.1.1 requires github.com/Hari-Kiri/virest-utilities@v0.1.1: parsing go.mod:
        module declares its path as: github.com/Hari-Kiri/virest-utilities/utils
                but was required as: github.com/Hari-Kiri/virest-utilities