### PR TITLE
fix: module path name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Hari-Kiri/virest-utilitiess
+module github.com/Hari-Kiri/virest-utilities
 
 go 1.23.4
 


### PR DESCRIPTION
Fix error when importing from another virest

> go: downloading github.com/Hari-Kiri/virest-utilities v0.1.2
go: github.com/Hari-Kiri/virest-utilities@v0.1.2 requires github.com/Hari-Kiri/virest-utilities@v0.1.2: parsing go.mod:
        module declares its path as: github.com/Hari-Kiri/virest-utilitiess
                but was required as: github.com/Hari-Kiri/virest-utilities