### PR TITLE
fix: module path name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Hari-Kiri/virest-utilitiess
+module github.com/Hari-Kiri/virest-utilities
 
 go 1.23.4
 

--- a/utils/NoContentResponseBuilder.go
+++ b/utils/NoContentResponseBuilder.go
@@ -2,7 +2,7 @@ package utils
 
 import "net/http"
 
-// Create http response with no content. Use case is for "PUT", "PATCH" and "DELETE" method.
+// Create http response with no content (HTTP code 204).
 func NoContentResponseBuilder(httpResponseWriter http.ResponseWriter) {
 	httpResponseWriter.WriteHeader(http.StatusNoContent)
 	httpResponseWriter.Write(nil)


### PR DESCRIPTION
Fix error when importing from another virest

> go: downloading github.com/Hari-Kiri/virest-utilities v0.1.2
go: github.com/Hari-Kiri/virest-utilities@v0.1.2 requires github.com/Hari-Kiri/virest-utilities@v0.1.2: parsing go.mod:
        module declares its path as: github.com/Hari-Kiri/virest-utilitiess
                but was required as: github.com/Hari-Kiri/virest-utilities