### PR TITLE
feat(hypervisor): idiomatic libvirt connect API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # virest-utilities
-ViRest utility tools
+
+ViRest utility tools.
+
+## Hypervisor connection
+
+Prefer the idiomatic connect helpers in `utils/hypervisor` (returns `(virest.Connection, error)` and does not require importing the parent `utils` package, which pulls in libguestfs via disk helpers):
+
+```go
+import "github.com/Hari-Kiri/virest-utilities/utils/hypervisor"
+
+conn, err := hypervisor.Connect("qemu:///system")
+if err != nil {
+    return err
+}
+defer conn.Close()
+```
+
+Also available: `ConnectReadOnly`, `ConnectWithAuth`, `ConnectWithAuthDefault`.
+
+Legacy `utils.NewConnect*` helpers remain for compatibility but are deprecated; they now delegate to `utils/hypervisor` and surface non-libvirt failures correctly via `hypervisor.ToLegacy`.

--- a/utils/HypervisorConnector.go
+++ b/utils/HypervisorConnector.go
@@ -1,67 +1,53 @@
 package utils
 
 import (
+	"github.com/Hari-Kiri/virest-utilities/utils/hypervisor"
 	"github.com/Hari-Kiri/virest-utilities/utils/structures/virest"
 	"libvirt.org/go/libvirt"
 )
 
-// This function should be called first to get a connection to the Hypervisor and xen store.
+// NewConnect opens a connection to the hypervisor at uri.
 //
-// If name is NULL, if the LIBVIRT_DEFAULT_URI environment variable is set, then it will be used.
-// Otherwise if the client configuration file has the "uri_default" parameter set, then it will be used.
-// Finally probing will be done to determine a suitable default driver to activate.
-// This involves trying each hypervisor in turn until one successfully opens.
-//
-// If connecting to an unprivileged hypervisor driver which requires the libvirtd daemon to be active,
-// it will automatically be launched if not already running. This can be prevented by setting the environment variable LIBVIRT_AUTOSTART=0
+// Deprecated: prefer hypervisor.Connect for idiomatic (Connection, error) results
+// and to avoid importing the parent utils package when you only need libvirt connect.
 //
 // URIs are documented at https://libvirt.org/uri.html
-//
 // Close() should be used to release the resources after the connection is no longer needed.
 func NewConnect(uri string) (virest.Connection, virest.Error, bool) {
-	result, errorResult := libvirt.NewConnect(uri)
-	libvirtError, isError := errorResult.(libvirt.Error)
-	return virest.Connection{Connect: result}, virest.Error{Error: libvirtError}, isError
+	conn, err := hypervisor.Connect(uri)
+	ve, isErr := hypervisor.ToLegacy(err)
+	return conn, ve, isErr
 }
 
-// This function should be called first to get a restricted connection to the library functionalities.
-// The set of APIs usable are then restricted on the available methods to control the domains.
+// NewConnectReadOnly opens a read-only connection to the hypervisor at uri.
 //
-// See https://pkg.go.dev/github.com/Hari-Kiri/virest-storage-pool/modules/utils#NewConnect or
-// https://libvirt.org/html/libvirt-libvirt-host.html#virConnectOpen for notes about environment variables
-// which can have an effect on opening drivers and freeing the connection resources
+// Deprecated: prefer hypervisor.ConnectReadOnly.
 //
 // URIs are documented at https://libvirt.org/uri.html
 func NewConnectReadOnly(uri string) (virest.Connection, virest.Error, bool) {
-	result, errorResult := libvirt.NewConnectReadOnly(uri)
-	libvirtError, isError := errorResult.(libvirt.Error)
-	return virest.Connection{Connect: result}, virest.Error{Error: libvirtError}, isError
+	conn, err := hypervisor.ConnectReadOnly(uri)
+	ve, isErr := hypervisor.ToLegacy(err)
+	return conn, ve, isErr
 }
 
-// This function should be called first to get a connection to the Hypervisor. If necessary, authentication
-// will be performed fetching credentials via the callback
+// NewConnectWithAuth opens a connection, invoking auth when credentials are required.
 //
-// See https://pkg.go.dev/github.com/Hari-Kiri/virest-storage-pool/modules/utils#NewConnect or
-// https://libvirt.org/html/libvirt-libvirt-host.html#virConnectOpen for notes about environment variables
-// which can have an effect on opening drivers and freeing the connection resources
+// Deprecated: prefer hypervisor.ConnectWithAuth.
 //
 // URIs are documented at https://libvirt.org/uri.html
 func NewConnectWithAuth(uri string, auth *libvirt.ConnectAuth, flags libvirt.ConnectFlags) (virest.Connection, virest.Error, bool) {
-	result, errorResult := libvirt.NewConnectWithAuth(uri, auth, flags)
-	libvirtError, isError := errorResult.(libvirt.Error)
-	return virest.Connection{Connect: result}, virest.Error{Error: libvirtError}, isError
+	conn, err := hypervisor.ConnectWithAuth(uri, auth, flags)
+	ve, isErr := hypervisor.ToLegacy(err)
+	return conn, ve, isErr
 }
 
-// This function should be called first to get a connection to the Hypervisor. If necessary, authentication
-// will be performed fetching credentials via the callback
+// NewConnectWithAuthDefault opens a connection using libvirt's default auth callback.
 //
-// See https://pkg.go.dev/github.com/Hari-Kiri/virest-storage-pool/modules/utils#NewConnect or
-// https://libvirt.org/html/libvirt-libvirt-host.html#virConnectOpen for notes about environment variables
-// which can have an effect on opening drivers and freeing the connection resources
+// Deprecated: prefer hypervisor.ConnectWithAuthDefault.
 //
 // URIs are documented at https://libvirt.org/uri.html
 func NewConnectWithAuthDefault(uri string, flags libvirt.ConnectFlags) (virest.Connection, virest.Error, bool) {
-	result, errorResult := libvirt.NewConnectWithAuthDefault(uri, flags)
-	libvirtError, isError := errorResult.(libvirt.Error)
-	return virest.Connection{Connect: result}, virest.Error{Error: libvirtError}, isError
+	conn, err := hypervisor.ConnectWithAuthDefault(uri, flags)
+	ve, isErr := hypervisor.ToLegacy(err)
+	return conn, ve, isErr
 }

--- a/utils/hypervisor/connect.go
+++ b/utils/hypervisor/connect.go
@@ -1,0 +1,74 @@
+package hypervisor
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Hari-Kiri/virest-utilities/utils/structures/virest"
+	"libvirt.org/go/libvirt"
+)
+
+// Connect opens a connection to the hypervisor at uri.
+// See https://libvirt.org/uri.html for URI formats (including local UNIX sockets
+// such as qemu:///system and remote transports such as qemu+ssh://...).
+//
+// Close the returned connection with Connection.Close when finished.
+func Connect(uri string) (virest.Connection, error) {
+	conn, err := libvirt.NewConnect(uri)
+	return wrapConnect(conn, err, "connect")
+}
+
+// ConnectReadOnly opens a read-only connection to the hypervisor at uri.
+func ConnectReadOnly(uri string) (virest.Connection, error) {
+	conn, err := libvirt.NewConnectReadOnly(uri)
+	return wrapConnect(conn, err, "connect read-only")
+}
+
+// ConnectWithAuth opens a connection, invoking auth when credentials are required.
+func ConnectWithAuth(uri string, auth *libvirt.ConnectAuth, flags libvirt.ConnectFlags) (virest.Connection, error) {
+	conn, err := libvirt.NewConnectWithAuth(uri, auth, flags)
+	return wrapConnect(conn, err, "connect with auth")
+}
+
+// ConnectWithAuthDefault opens a connection using libvirt's default auth callback.
+func ConnectWithAuthDefault(uri string, flags libvirt.ConnectFlags) (virest.Connection, error) {
+	conn, err := libvirt.NewConnectWithAuthDefault(uri, flags)
+	return wrapConnect(conn, err, "connect with auth default")
+}
+
+func wrapConnect(conn *libvirt.Connect, err error, op string) (virest.Connection, error) {
+	if err != nil {
+		return virest.Connection{}, fmt.Errorf("%s: %w", op, err)
+	}
+	if conn == nil {
+		return virest.Connection{}, fmt.Errorf("%s: nil libvirt connection", op)
+	}
+	return virest.Connection{Connect: conn}, nil
+}
+
+// AsLibvirtError extracts a libvirt.Error from err when present.
+func AsLibvirtError(err error) (libvirt.Error, bool) {
+	var lv libvirt.Error
+	if errors.As(err, &lv) {
+		return lv, true
+	}
+	return libvirt.Error{}, false
+}
+
+// ToLegacy converts an idiomatic error into the historical (virest.Error, bool) pair.
+// Non-libvirt errors are preserved as a libvirt.Error with Message set so callers
+// that only inspect Message still see the failure.
+func ToLegacy(err error) (virest.Error, bool) {
+	if err == nil {
+		return virest.Error{}, false
+	}
+	if lv, ok := AsLibvirtError(err); ok {
+		return virest.Error{Error: lv}, true
+	}
+	return virest.Error{Error: libvirt.Error{
+		Code:    libvirt.ERR_INTERNAL_ERROR,
+		Domain:  libvirt.FROM_NONE,
+		Message: err.Error(),
+		Level:   libvirt.ERR_ERROR,
+	}}, true
+}

--- a/utils/hypervisor/connect_test.go
+++ b/utils/hypervisor/connect_test.go
@@ -1,0 +1,45 @@
+package hypervisor_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/Hari-Kiri/virest-utilities/utils/hypervisor"
+	"libvirt.org/go/libvirt"
+)
+
+func TestAsLibvirtError(t *testing.T) {
+	lv := libvirt.Error{Code: libvirt.ERR_AUTH_FAILED, Message: "denied"}
+	got, ok := hypervisor.AsLibvirtError(lv)
+	if !ok || got.Code != libvirt.ERR_AUTH_FAILED {
+		t.Fatalf("expected libvirt error, got ok=%v err=%+v", ok, got)
+	}
+
+	wrapped := fmt.Errorf("connect: %w", lv)
+	got, ok = hypervisor.AsLibvirtError(wrapped)
+	if !ok || got.Message != "denied" {
+		t.Fatalf("expected wrapped libvirt error, got ok=%v err=%+v", ok, got)
+	}
+
+	if _, ok := hypervisor.AsLibvirtError(errors.New("plain")); ok {
+		t.Fatal("plain error should not match")
+	}
+}
+
+func TestToLegacy(t *testing.T) {
+	ve, isErr := hypervisor.ToLegacy(nil)
+	if isErr || ve.Message != "" {
+		t.Fatalf("nil should be success: %+v %v", ve, isErr)
+	}
+
+	ve, isErr = hypervisor.ToLegacy(libvirt.Error{Code: libvirt.ERR_NO_CONNECT, Message: "down"})
+	if !isErr || ve.Code != libvirt.ERR_NO_CONNECT {
+		t.Fatalf("expected libvirt legacy error: %+v", ve)
+	}
+
+	ve, isErr = hypervisor.ToLegacy(errors.New("boom"))
+	if !isErr || ve.Message != "boom" || ve.Code != libvirt.ERR_INTERNAL_ERROR {
+		t.Fatalf("expected synthesized legacy error: %+v", ve)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `utils/hypervisor` with idiomatic `(Connection, error)` connect helpers and proper `%w` error wrapping
- Delegate deprecated `utils.NewConnect*` wrappers through the new package so non-libvirt errors are not dropped
- Document preferring `utils/hypervisor` when only libvirt connectivity is needed (avoids pulling parent `utils` / libguestfs)

## Test plan
- [ ] `CGO_ENABLED=1 go test ./utils/hypervisor/`
- [ ] Import `utils/hypervisor` and connect with `qemu:///system`
- [ ] Confirm legacy `utils.NewConnect` still returns `(Connection, Error, bool)` for existing callers


Made with [Cursor](https://cursor.com)